### PR TITLE
Add default value for lambda_k; edited description text for d_spacing_perpendicular with origin and use

### DIFF
--- a/cif_pow.dic
+++ b/cif_pow.dic
@@ -6197,14 +6197,20 @@ save_pd_proc.d_spacing_perpendicular
 ;
     d-spacing perpendicular, when combined with d-spacing, allows for a
     two-dimensional treatment of neutron TOF powder data, taking into
-    account the variation of the diffraction angle, θ, and wavelength, λ.
+    account the variation of the diffraction angle, 2θ, and wavelength, λ.
 
     The values are given by
 
     d~⟂~ = sqrt(λ² - 2 λₖ² ln(cosθ))  (Å)
 
     where λ is the wavelength in ångstroms, θ is the Bragg angle, and λₖ is
-    an arbitrary constant, see _pd_proc_overall.lambda_k
+    an arbitrary constant, see _pd_proc_overall.lambda_k.
+
+    The formula for d~⟂~ is a solution to the differential equation
+    demanding an orthogonal axis to d-spacing in the (2θ,λ) plane.
+    Any (2θ,λ)-coordinate can be transformed to a (d,d~⟂~)-coordinate, 
+    with the effect that sinusoidal Bragg-reflections become vertical 
+    with minimal peak width in the orthogonal d~⟂~-direction.
 
     See:
     Philipp Jacobs et al. (2015). J. Appl. Cryst. 48, 1627-1636.
@@ -12560,6 +12566,7 @@ save_pd_proc_overall.lambda_k
     _type.container               Single
     _type.contents                Real
     _enumeration.range            0.0:
+    _enumeration.default          1.0
     _units.code                   angstroms
 
 save_


### PR DESCRIPTION
Thank you very much @rowlesmr and @vaitkus for the work you already did so quickly! I wasn't aware of that, so I'm answering so late. Sorry for that.

I would like to propose only minor changes:
- `pd_proc_overall.lambda_k` should have an default value of 1.0 A. The constant might be understood as an aspect ratio of the two coordinates and of course it also fixes the unit in the d⟂ formula. I'm not sure if we need to add this explanation to the source code, so I just write it here.
- In `_pd_proc.d_spacing_perpendicular`, I would like to add some more explanation though. Since also 2θ and texture angle are sometimes nominated as two-dimensional, I think it is needed to add the relation between (2θ,λ) and (d,d⟂) coordinates and state the effect on the data. I tried to be as short as possible.

Compared to the cif holding e.g. two-dimensional diamond-data measured with the [POWTEX@MLZ](https://mlz-garching.de/powtex/de) detector at the POWGEN instrument (see supplementary information of [POWTEX visits POWGEN](https://doi.org/10.1107/S1600576723002819/tu5033sup1.zip)), with this change `_pd_proc_ls_special_details` would be expressed as `_pd_proc_d_spacing_perpendicular` in the future.